### PR TITLE
update node_printer.cc for context awareness

### DIFF
--- a/src/node_printer.cc
+++ b/src/node_printer.cc
@@ -2,21 +2,25 @@
 
 #include <node_buffer.h>
 
-void initNode(v8::Local<v8::Object> exports) {
+NAN_MODULE_INIT(Init) {
 // only for node
-    MY_MODULE_SET_METHOD(exports, "getPrinters", getPrinters);
-    MY_MODULE_SET_METHOD(exports, "getDefaultPrinterName", getDefaultPrinterName);
-    MY_MODULE_SET_METHOD(exports, "getPrinter", getPrinter);
-    MY_MODULE_SET_METHOD(exports, "getPrinterDriverOptions", getPrinterDriverOptions);
-    MY_MODULE_SET_METHOD(exports, "getJob", getJob);
-    MY_MODULE_SET_METHOD(exports, "setJob", setJob);
-    MY_MODULE_SET_METHOD(exports, "printDirect", PrintDirect);
-    MY_MODULE_SET_METHOD(exports, "printFile", PrintFile);
-    MY_MODULE_SET_METHOD(exports, "getSupportedPrintFormats", getSupportedPrintFormats);
-    MY_MODULE_SET_METHOD(exports, "getSupportedJobCommands", getSupportedJobCommands);
+    MY_MODULE_SET_METHOD(target, "getPrinters", getPrinters);
+    MY_MODULE_SET_METHOD(target, "getDefaultPrinterName", getDefaultPrinterName);
+    MY_MODULE_SET_METHOD(target, "getPrinter", getPrinter);
+    MY_MODULE_SET_METHOD(target, "getPrinterDriverOptions", getPrinterDriverOptions);
+    MY_MODULE_SET_METHOD(target, "getJob", getJob);
+    MY_MODULE_SET_METHOD(target, "setJob", setJob);
+    MY_MODULE_SET_METHOD(target, "printDirect", PrintDirect);
+    MY_MODULE_SET_METHOD(target, "printFile", PrintFile);
+    MY_MODULE_SET_METHOD(target, "getSupportedPrintFormats", getSupportedPrintFormats);
+    MY_MODULE_SET_METHOD(target, "getSupportedJobCommands", getSupportedJobCommands);
 }
 
-NODE_MODULE(node_printer, initNode);
+#if NODE_MAJOR_VERSION >= 10
+NAN_MODULE_WORKER_ENABLED(node_printer, Init)
+#else
+NODE_MODULE(node_printer, Init)
+#endif
 
 // Helpers
 


### PR DESCRIPTION
As mentioned in #23 the modul has to be context aware to be used in electron 14+.
I have tested the changes successfully for windows 10