### PR TITLE
use python3 instead of python

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,7 +20,7 @@
       'sources': [
         # is like "ls -1 src/*.cc", but gyp does not support direct patterns on
         # sources
-        '<!@(["python", "tools/getSourceFiles.py", "src", "cc"])'
+        '<!@(["python3", "tools/getSourceFiles.py", "src", "cc"])'
       ],
       'include_dirs' : [
         "<!(node -e \"require('nan')\")"


### PR DESCRIPTION
Now node-gyp only supports python3 for a while... let's use `python3` executable instead of `python` - for systems not shipping `python` by default.