### PR TITLE
Fix missing `options` property on `PrintFileOptions`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,6 +22,7 @@ export interface PrintDirectOptions {
 export interface PrintFileOptions {
     filename: string;
     printer?: string | undefined;
+    options?: { [key: string]: string } | undefined;
     success?: PrintOnSuccessFunction | undefined;
     error?: PrintOnErrorFunction | undefined;
 }


### PR DESCRIPTION
I noticed that `printDirect()` took an `options` parameter but `printFile()` no longer did.

Looking at the source, `printFile()` still accepts `options`, but it was just missing in the type interface.
This PR simply adds it back in.
