### PR TITLE
Fix for Compatibility with Electron 20+ Versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "main": "./lib/printer",
   "dependencies": {
-    "nan": "^2.15.0",
+    "nan": "^2.18.0",
     "prebuild-install": "^7.0.1"
   },
   "types": "types/index.d.ts"


### PR DESCRIPTION
This Pull Request implements an update to the nan module to ensure compatibility with Electron version 20 and beyond. Recent changes in Electron's V8 engine necessitated this update, which modifies native node module bindings to align with the updated V8 API. 

Fix for: https://github.com/thiagoelg/node-printer/issues/56 https://github.com/thiagoelg/node-printer/issues/45
